### PR TITLE
🐛Bug: CORS Preflight 요청(OPTIONS) 403 에러 발생

### DIFF
--- a/src/main/java/com/chapssal_tteok/preview/global/config/WebConfig.java
+++ b/src/main/java/com/chapssal_tteok/preview/global/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.chapssal_tteok.preview.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://172.24.112.1:3000") // 프론트 주소
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}


### PR DESCRIPTION
## :link: 연관된 이슈
- #25 

## :memo: 작업 내용
CORS 관련 설정을 추가하여 브라우저가 보내는 OPTIONS Preflight 요청에 대해 서버가 정상적으로 CORS 허용 응답(200 OK)을 반환하고, 이후 본 요청(POST /register)이 정상적으로 전송 및 처리되도록 하였다.
