### PR TITLE
🐛Bug: CORS Preflight 요청(OPTIONS) 403 에러 발생 2

### DIFF
--- a/src/main/java/com/chapssal_tteok/preview/global/config/DevCorsConfig.java
+++ b/src/main/java/com/chapssal_tteok/preview/global/config/DevCorsConfig.java
@@ -1,17 +1,19 @@
 package com.chapssal_tteok.preview.global.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class WebConfig implements WebMvcConfigurer {
+@Profile("dev") // 개발 환경
+public class DevCorsConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://172.24.112.1:3000") // 프론트 주소
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedOriginPatterns("*") // 개발 시 전체 허용
+                .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);
     }

--- a/src/main/java/com/chapssal_tteok/preview/global/config/ProdCorsConfig.java
+++ b/src/main/java/com/chapssal_tteok/preview/global/config/ProdCorsConfig.java
@@ -1,0 +1,20 @@
+package com.chapssal_tteok.preview.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@Profile("prod") // 운영 환경
+public class ProdCorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://172.24.112.1:3000") // 프론트 주소
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}


### PR DESCRIPTION
## :link: 연관된 이슈
- #28 

## :memo: 작업 내용
WebConfig 파일을 ProdCorsConfig와 DevCorsConfig로 분리하였다.
- 개발 환경(dev)일 때는 모든 Origin을 허용하도록 설정하였다.
- 운영 환경(prod)일 때는 배포된 프론트엔드 도메인만 허용하도록 설정하였다.
```
spring:
  profiles:
    active: dev
```
application.yml에서 설정해주면 된다.
주의! 운영 배포 시 반드시 application.yml에서 spring.profiles.active를 prod로 변경해야 한다.
